### PR TITLE
Move DaemonSet apiVersion from extensions/v1beta1 to apps/v1

### DIFF
--- a/deployments/daemonset-install.yaml
+++ b/deployments/daemonset-install.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: route-override

--- a/deployments/daemonset-install.yaml
+++ b/deployments/daemonset-install.yaml
@@ -8,6 +8,10 @@ metadata:
     tier: node
     app: route-override
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: route-override
   updateStrategy:
     type: RollingUpdate
   template:
@@ -19,27 +23,27 @@ spec:
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
+        - operator: Exists
+          effect: NoSchedule
       containers:
-      - name: route-override
-        image: nfvpe/cni-route-override:latest
-        command: ["/bin/sh"]
-        args:
-          - "-c"
-          - "cp -f /route-override /host/opt/cni/bin/; sleep 1000000000000"
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-          limits:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cnibin
-          mountPath: /host/opt/cni/bin
+        - name: route-override
+          image: nfvpe/cni-route-override:latest
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "cp -f /route-override /host/opt/cni/bin/; sleep 1000000000000"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
       volumes:
         - name: cnibin
           hostPath:


### PR DESCRIPTION
The move of the Daemonset-api to `apps/v1` was introduced in [Kubernetes v1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#workloads-api-appsv1) and since [v1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) the old api has been removed. With its current daemonset-deployment this plugin does not support Kubernetes v1.16 or later!
With my changes from this PR the latest supported version would be 1.9 which has reached its EOL a long time ago.

I also added the required `selector` labels for linking the pod to the daemonset