### PR TITLE
Build statically linked binary in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM golang:1.23 AS build
 # Add everything
 ADD . /usr/src/cni-route-override
 
+ENV CGO_ENABLED=0
+
 RUN cd /usr/src/cni-route-override && \
     ./build_linux.sh
 


### PR DESCRIPTION
I'm trying to use route-override on my machine running nixos and running into issues as the binary built in the docker image is built with dynamic linking.

The binary built using goreleaser is statically linked so with this change the docker built binary will be in line with the one built by goreleaser.